### PR TITLE
refactor: remove props and use default routes in astro breadcrumb

### DIFF
--- a/src/components/react/astro-breadcrumb.tsx
+++ b/src/components/react/astro-breadcrumb.tsx
@@ -13,11 +13,8 @@ const astroRoutes = [
   },
 ];
 
-type Props = Pick<React.ComponentProps<typeof Breadcrumb>, "routes">;
-
-export const AstroBreadcrumb = ({ routes }: Props) => {
-  const buildRoutes = { ...astroRoutes, ...routes };
-  return <Breadcrumb routes={buildRoutes} />;
+export const AstroBreadcrumb = () => {
+  return <Breadcrumb routes={astroRoutes} />;
 };
 
 export default AstroBreadcrumb;


### PR DESCRIPTION
The AstroBreadcrumb component no longer accepts routes as a prop. It now directly uses the default astroRoutes instead of merging them with any passed in routes.