### PR TITLE
Feat/custom-routes

### DIFF
--- a/src/components/react/astro-breadcrumb.tsx
+++ b/src/components/react/astro-breadcrumb.tsx
@@ -1,4 +1,5 @@
 import { Breadcrumb } from "@fpkit/react";
+import type React from "react";
 
 const astroRoutes = [
   {
@@ -13,8 +14,13 @@ const astroRoutes = [
   },
 ];
 
-export const AstroBreadcrumb = () => {
-  return <Breadcrumb routes={astroRoutes} />;
+type AstroRoutes = Pick<React.ComponentProps<typeof Breadcrumb>, "routes">;
+
+export const AstroBreadcrumb = ({ routes }: AstroRoutes) => {
+  const builtRoutes = routes ? [...routes, ...astroRoutes] : astroRoutes;
+  console.log(builtRoutes);
+
+  return <Breadcrumb routes={builtRoutes} />;
 };
 
 export default AstroBreadcrumb;

--- a/src/content/posts/post-2.md
+++ b/src/content/posts/post-2.md
@@ -1,7 +1,7 @@
 ---
 title: My Second Blog Post
 author: Astro Learner
-description: "After learning some Astro, I couldn't stop!"
+description: "After learning some Astro, I couldn't stop! lorem ipsum dolor sit amet, consectetur adipiscing elit."
 image:
     url: "https://docs.astro.build/assets/arc.webp"
     alt: "Thumbnail of Astro arcs."

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -6,6 +6,16 @@ import Header from "../components/astro/Header.astro";
 import Sidebar from "../components/astro/Sidebar.astro";
 import AstroBreadcrumb from "#components/react/astro-breadcrumb.tsx";
 import "@fpkit/react/styles";
+
+// types
+type Props = {
+  pageTitle: string;
+  pageDescription: string;
+  showBreadcrumb: boolean;
+};
+
+const showBreadcrumb = Astro.props.showBreadcrumb || true;
+
 const { pageTitle, pageDescription } = Astro.props;
 import "../styles/index.css";
 ---
@@ -28,7 +38,7 @@ import "../styles/index.css";
     <main>
       <section arai-label="main-content">
         <article>
-          <div><AstroBreadcrumb client:load /></div>
+          <div>{showBreadcrumb && <AstroBreadcrumb client:load />}</div>
           <hr />
           <slot />
         </article>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -9,14 +9,16 @@ import "@fpkit/react/styles";
 
 // types
 type Props = {
-  pageTitle: string;
-  pageDescription: string;
-  showBreadcrumb: boolean;
+  pageTitle?: string;
+  pageDescription?: string;
+  showBreadcrumb?: boolean;
+  breadcrumbRoutes?: [];
 };
 
-const showBreadcrumb = Astro.props.showBreadcrumb || true;
+const showBreadcrumb =
+  Astro.props.showBreadcrumb === undefined ? true : Astro.props.showBreadcrumb;
 
-const { pageTitle, pageDescription } = Astro.props;
+const { pageTitle, pageDescription, breadcrumbRoutes } = Astro.props;
 import "../styles/index.css";
 ---
 
@@ -38,8 +40,19 @@ import "../styles/index.css";
     <main>
       <section arai-label="main-content">
         <article>
-          <div>{showBreadcrumb && <AstroBreadcrumb client:load />}</div>
-          <hr />
+          {
+            showBreadcrumb && (
+              <>
+                <div>
+                  <AstroBreadcrumb
+                    routes={breadcrumbRoutes || undefined}
+                    client:load
+                  />
+                </div>
+                <hr />
+              </>
+            )
+          }
           <slot />
         </article>
         <Sidebar />

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -4,7 +4,7 @@ import CollectionList from "#components/astro/CollectionList.astro";
 import Welcome from "#components/astro/Welcome.astro";
 ---
 
-<Layout pageTitle="Astro Kit">
+<Layout pageTitle="Astro Kit" showBreadcrumb={false}>
   <Welcome />
   <section>
     <CollectionList pageSize={2} />

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -10,6 +10,12 @@ main > section {
   padding-inline: 2rem;
 }
 
+header {
+  min-height: fit-content;
+  padding-block: 2rem;
+  grid-template-rows: minmax(300px, auto);
+}
+
 header > section > p {
   font-size: 2rem;
 }


### PR DESCRIPTION
- Make pageTitle, pageDescription and showBreadcrumb props optional in Layout component
- Add breadcrumbRoutes prop to Layout to customize breadcrumb links
- Update Home page to not show breadcrumbs