### PR TITLE
feat: add post sorting by publish date

### DIFF
--- a/src/components/astro/PostsList.astro
+++ b/src/components/astro/PostsList.astro
@@ -3,6 +3,7 @@ import { getCollection } from "astro:content";
 const postListTitle = Astro.props.postListTitle || "Latest Posts";
 const postLength = Astro.props.postLength || 10;
 const allPosts = await getCollection("posts");
+allPosts.sort((a, b) => b.data.pubDate.getTime() - a.data.pubDate.getTime());
 const paginatedPosts = allPosts.slice(0, postLength);
 ---
 


### PR DESCRIPTION
Sort posts by publish date in descending order before slicing posts for pagination. This will ensure the most recently published posts are shown first in the paginated list.