### PR TITLE
refactor: replace image component with plain img tag

### DIFF
--- a/src/components/astro/Img.astro
+++ b/src/components/astro/Img.astro
@@ -14,7 +14,7 @@ const caption = imgCaption ? "" : imgAlt;
 ---
 
 <figure>
-  <Image
+  <img
     src={imgSrc}
     alt=`${imgAlt}`
     width={imgWidth || 500}


### PR DESCRIPTION
The Image component was replaced with a plain img tag in the Img.astro component.