### PR TITLE
feat(navigation): update login slot structure for SignedIn and Signed…

### DIFF
--- a/src/components/astro/Navigation.astro
+++ b/src/components/astro/Navigation.astro
@@ -19,17 +19,6 @@ import { SignedIn } from "@clerk/astro/components";
     <li>
       <a href="/contact">Contact</a>
     </li>
-
-    <!-- <li>
-      <SignedIn isStatic={true}>
-        <a href="/events">Events</a>
-      </SignedIn>
-    </li> -->
-    <li>
-      <SignedIn isStatic={true}>
-        <a href="/dashboard">Dashboard</a>
-      </SignedIn>
-    </li>
   </ul>
   <slot />
   <slot name="login" />

--- a/src/components/astro/Navigation.astro
+++ b/src/components/astro/Navigation.astro
@@ -19,20 +19,18 @@ import { SignedIn } from "@clerk/astro/components";
     <li>
       <a href="/contact">Contact</a>
     </li>
+
+    <!-- <li>
+      <SignedIn isStatic={true}>
+        <a href="/events">Events</a>
+      </SignedIn>
+    </li> -->
+    <li>
+      <SignedIn isStatic={true}>
+        <a href="/dashboard">Dashboard</a>
+      </SignedIn>
+    </li>
   </ul>
   <slot />
-  <SignedIn isStatic={true}>
-    <ul>
-      <li>
-        <a href="/events">Events</a>
-      </li>
-      <li>
-        <a href="/dashboard">Dashboard</a>
-      </li>
-
-      <li>
-        <slot name="login" />
-      </li>
-    </ul>
-  </SignedIn>
+  <slot name="login" />
 </nav>

--- a/src/layouts/Auth.astro
+++ b/src/layouts/Auth.astro
@@ -6,6 +6,7 @@ const { pageTitle, pageDescription, pageImageUrl, hideHeader } = Astro.props;
 
 <Layout
   hideHeader={true}
+  showBreadcrumb={false}
   pageTitle={pageTitle || "Authentication"}
   pageDescription={pageDescription || "Sign in to your account"}
 >

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -56,14 +56,26 @@ const {
   </head>
   <body>
     <Navigation>
-      <div slot="login">
-        <SignedIn isStatic={true}>
-          <UserButton />
-        </SignedIn>
-        <SignedOut isStatic={true}>
-          <SignInButton mode="modal" />
-        </SignedOut>
-      </div>
+      <ul slot="login">
+        <li>
+          <SignedIn isStatic={true}>
+            <a href="/events">Events</a>
+          </SignedIn>
+        </li>
+        <li>
+          <SignedIn isStatic={true}>
+            <a href="/dashboard">Dashboard</a>
+          </SignedIn>
+        </li>
+        <li>
+          <SignedIn isStatic={true}>
+            <UserButton />
+          </SignedIn>
+          <SignedOut isStatic={true}>
+            <SignInButton mode="modal" />
+          </SignedOut>
+        </li>
+      </ul>
     </Navigation>
 
     {


### PR DESCRIPTION
…Out components

- Refactored the login slot in the Layout.astro file to use an unordered list for better semantic structure.
- Added links for "Events" and "Dashboard" within the SignedIn component.
- Retained the UserButton and SignInButton within the same list item for improved user experience.

Files changed:
- src/layouts/Layout.astro
- src/components/astro/Navigation.astro
This pull request introduces updates to the navigation structure, layout components, and a new admin page in the Astro project. The most important changes include restructuring navigation links for authenticated users, adding a new `showBreadcrumb` prop to the `Auth` layout, and creating an admin dashboard page.

### Navigation and Layout Updates:
* [`src/components/astro/Navigation.astro`](diffhunk://#diff-e88da1ea01c7590ca8fff9cba48626fe74ab27a74a9384efeff889cf6d04f35cL22-L32): Removed commented-out and unused `<SignedIn>` navigation links for `/events` and `/dashboard`.
* [`src/layouts/Layout.astro`](diffhunk://#diff-ba00f1d7bc63648f0861e03d786d6f1ed78307f1b40284e4db329586d3df2db2L59-R78): Reintroduced the `/events` and `/dashboard` links for authenticated users under the `login` slot in the `Navigation` component.

### Auth Layout Enhancements:
* [`src/layouts/Auth.astro`](diffhunk://#diff-78aae7cf01c5715ecf2b003850ca55ee4a3bd3c65d9b8a537e6d7bfccd3ff548R9): Added a new `showBreadcrumb` prop to the `Auth` layout, defaulting to `false` in this instance, to provide additional customization for pages using this layout.

### New Admin Page:
* [`src/pages/admin.astro`](diffhunk://#diff-30f82b17b3a00610d4391c5084e9c9df47fd532810352a814c027b39d2151cc1R1-R20): Introduced a new admin dashboard page with authentication checks. Authenticated users see admin actions (e.g., "Manage Users," "View Reports"), while unauthenticated users are prompted to sign in.