### PR TITLE
feat(MainSection): create MainSection component for breadcrumb functi…

### DIFF
--- a/src/components/astro/MainSection.astro
+++ b/src/components/astro/MainSection.astro
@@ -3,7 +3,6 @@ import AstroBreadcrumb from '#components/react/astro-breadcrumb.tsx'
 
 export type Props = {
   showBreadcrumb?: boolean
-  hideHeader?: boolean
   breadcrumbRoutes?: Array<{
     name: string
     url: string
@@ -11,18 +10,19 @@ export type Props = {
   }>
 }
 
-const { showBreadcrumb = false, breadcrumbRoutes = [], hideHeader = false } = Astro.props
+const { showBreadcrumb, breadcrumbRoutes } = Astro.props
 ---
 
-<main>
-  <div>
+<>
+  <slot name="featured" />
+  <main>
     {
       showBreadcrumb && (
-        <>
+        <section>
           <AstroBreadcrumb routes={breadcrumbRoutes || []} client:load />
-        </>
+        </section>
       )
     }
-  </div>
-  <slot />
-</main>
+    <slot />
+  </main>
+</>

--- a/src/components/astro/MainSection.astro
+++ b/src/components/astro/MainSection.astro
@@ -1,0 +1,28 @@
+---
+import AstroBreadcrumb from '#components/react/astro-breadcrumb.tsx'
+
+export type Props = {
+  showBreadcrumb?: boolean
+  hideHeader?: boolean
+  breadcrumbRoutes?: Array<{
+    name: string
+    url: string
+    path?: string
+  }>
+}
+
+const { showBreadcrumb = false, breadcrumbRoutes = [], hideHeader = false } = Astro.props
+---
+
+<main>
+  <div>
+    {
+      showBreadcrumb && (
+        <>
+          <AstroBreadcrumb routes={breadcrumbRoutes || []} client:load />
+        </>
+      )
+    }
+  </div>
+  <slot />
+</main>

--- a/src/layouts/Auth.astro
+++ b/src/layouts/Auth.astro
@@ -1,4 +1,5 @@
 ---
+import MainSection from '#components/astro/MainSection.astro'
 import Base from './Base.astro'
 
 const { pageTitle, pageDescription, pageImageUrl, hideHeader } = Astro.props
@@ -11,5 +12,7 @@ const { pageTitle, pageDescription, pageImageUrl, hideHeader } = Astro.props
   pageDescription=""
   pageImageUrl={pageImageUrl}
 >
-  <slot />
+  <MainSection showBreadcrumb={false}>
+    <slot />
+  </MainSection>
 </Base>

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -10,7 +10,6 @@ import { SITE_DESCRIPTION, SITE_TITLE } from '#utils/site-config'
 import '@fpkit/acss/styles'
 import '../styles/index.css'
 import { SignedIn, SignedOut, UserButton, SignInButton } from '@clerk/astro/components'
-import AstroBreadcrumb from '#components/react/astro-breadcrumb.tsx'
 
 // types
 type routeItem = {

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -29,7 +29,7 @@ type Props = {
 
 const showBreadcrumb = Astro.props.showBreadcrumb === undefined ? true : Astro.props.showBreadcrumb
 
-const { pageTitle, pageDescription, breadcrumbRoutes, pageImageUrl, hideHeader } = Astro.props
+const { pageTitle, pageDescription, pageImageUrl, hideHeader } = Astro.props
 ---
 
 <html lang="en">
@@ -94,19 +94,7 @@ const { pageTitle, pageDescription, breadcrumbRoutes, pageImageUrl, hideHeader }
         />
       )
     }
-
-    <main>
-      <div>
-        {
-          showBreadcrumb && (
-            <>
-              <AstroBreadcrumb routes={breadcrumbRoutes || []} client:load />
-            </>
-          )
-        }
-      </div>
-      <slot />
-    </main>
+    <slot />
     <Footer />
 
     <!-- PWA Install Prompt -->

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -1,24 +1,29 @@
 ---
 import Base from './Base.astro'
 import Sidebar from '#components/astro/Sidebar.astro'
+import MainSection from '#components/astro/MainSection.astro'
 const { pageTitle, pageDescription, pageImageUrl, hideHeader } = Astro.props
 ---
 
 <Base
   hideHeader={hideHeader || false}
-  showBreadcrumb={true}
   pageTitle={pageTitle || 'Authentication'}
   pageDescription={pageDescription || 'Sign in to your account'}
   pageImageUrl={pageImageUrl}
 >
-  <section aria-label="main-content">
-    <article>
-      <slot />
-    </article>
-    <aside>
-      <slot name="sidebar" />
-      <Sidebar />
-      <slot name="sidebar-footer" />
-    </aside>
-  </section>
+  <MainSection showBreadcrumb={true}>
+    <div slot="featured">
+      <slot name="featured" />
+    </div>
+    <section aria-label="main-content">
+      <article>
+        <slot />
+      </article>
+      <aside>
+        <slot name="sidebar" />
+        <Sidebar />
+        <slot name="sidebar-footer" />
+      </aside>
+    </section>
+  </MainSection>
 </Base>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -2,7 +2,8 @@
 import Base from './Base.astro'
 import Sidebar from '#components/astro/Sidebar.astro'
 import MainSection from '#components/astro/MainSection.astro'
-const { pageTitle, pageDescription, pageImageUrl, hideHeader } = Astro.props
+const { pageTitle, pageDescription, pageImageUrl, hideHeader, showBreadcrumb, breadcrumbRoutes } =
+  Astro.props
 ---
 
 <Base
@@ -11,7 +12,7 @@ const { pageTitle, pageDescription, pageImageUrl, hideHeader } = Astro.props
   pageDescription={pageDescription || 'Sign in to your account'}
   pageImageUrl={pageImageUrl}
 >
-  <MainSection showBreadcrumb={true}>
+  <MainSection showBreadcrumb={showBreadcrumb || true} breadcrumbRoutes={breadcrumbRoutes || []}>
     <div slot="featured">
       <slot name="featured" />
     </div>

--- a/src/layouts/MarkdownPostLayout.astro
+++ b/src/layouts/MarkdownPostLayout.astro
@@ -3,7 +3,6 @@ import Layout from './Layout.astro'
 import Youtube from '#components/astro/Youtube.astro'
 import Img from '#components/astro/Img.astro'
 import Toc from '#components/astro/Toc.astro'
-import TextToSpeech from '#components/astro/TextToSpeech.astro'
 import { sanitizeImageUrl } from '#/utils/security'
 import type { TODO } from '#utils/types.js'
 const frontmatter = Astro.props.frontmatter


### PR DESCRIPTION
…onality

- Implemented a new `MainSection.astro` component to encapsulate breadcrumb logic and main content rendering.
- The component accepts props for showing breadcrumbs, hiding headers, and defining breadcrumb routes.
- This change aims to centralize breadcrumb functionality and improve code reusability across layouts.

Files changed:
- src/components/astro/MainSection.astro