### PR TITLE
fix: remove unused sectionTitle prop from FeatureCards component

### DIFF
--- a/src/components/astro/FeatureCards.astro
+++ b/src/components/astro/FeatureCards.astro
@@ -14,8 +14,6 @@ export type Props = {
   category?: FeatureCard['category']
   /** Show all features regardless of count */
   showAll?: boolean
-  /** Custom title for the features section */
-  sectionTitle?: string
   /** Custom CSS class for the container */
   className?: string
 }
@@ -24,7 +22,6 @@ const {
   count = 6,
   category,
   showAll = false,
-  sectionTitle = 'Key Features',
   className = '',
 } = Astro.props
 


### PR DESCRIPTION
This PR removes the unused `sectionTitle` prop from the FeatureCards component.

## Changes
- Removed `sectionTitle?: string` from Props type definition
- Removed `sectionTitle = 'Key Features'` from props destructuring

Fixes #168

Generated with [Claude Code](https://claude.ai/code)