### PR TITLE
fix: correct camelCase key transformation in getDataAttributes

### DIFF
--- a/public/scripts/modules/ui.js
+++ b/public/scripts/modules/ui.js
@@ -64,7 +64,11 @@ export function getDataAttributes(element, prefix = '') {
   
   for (const [key, value] of Object.entries(attrs)) {
     if (!prefix || key.startsWith(prefix)) {
-      const cleanKey = prefix ? key.replace(prefix, '').toLowerCase() : key;
+      const cleanKey = prefix
+        ? key.startsWith(prefix)
+          ? key.slice(prefix.length).replace(/^([A-Z])/, (m) => m.toLowerCase())
+          : key
+        : key;
       data[cleanKey] = value;
     }
   }

--- a/tests/scripts/ui.test.ts
+++ b/tests/scripts/ui.test.ts
@@ -143,7 +143,7 @@ describe('UI Module', () => {
       
       for (const [key, value] of Object.entries(element.dataset)) {
         if (key.startsWith(prefix)) {
-          const cleanKey = key.replace(prefix, '').toLowerCase()
+          const cleanKey = key.slice(prefix.length).replace(/^([A-Z])/, (m) => m.toLowerCase())
           data[cleanKey] = value
         }
       }


### PR DESCRIPTION
Fixes issue where prefix removal didn't properly handle camelCase.

- formEndpoint now correctly becomes 'endpoint' instead of 'endpoint'
- Uses slice() and regex to lowercase first letter after prefix removal
- Updates test to match corrected implementation

Resolves #226

Generated with [Claude Code](https://claude.ai/code)