### PR TITLE
fix: enable static prerendering for all content collection pages

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -59,6 +59,11 @@ export default defineConfig({
     }),
   ],
   output: 'server',
+  vite: {
+    ssr: {
+      noExternal: ['astro-imagetools']
+    }
+  },
   // Choose adapter based on deployment target
   adapter: (() => {
     const adapter = process.env.ASTRO_ADAPTER

--- a/src/pages/content/[...slug].astro
+++ b/src/pages/content/[...slug].astro
@@ -5,7 +5,7 @@ import MarkdownPostLayout from '../../layouts/MarkdownPostLayout.astro'
 
 export async function getStaticPaths() {
   const content = await getCollection('content')
-  return content.map(entry => ({
+  return content.map((entry: CollectionEntry<'content'>) => ({
     params: { slug: entry.slug },
     props: { entry },
   }))

--- a/src/pages/docs/[...slug].astro
+++ b/src/pages/docs/[...slug].astro
@@ -1,14 +1,18 @@
 ---
-export const prerender = false
-import { getCollection } from 'astro:content'
+export const prerender = true
+import { getCollection, type CollectionEntry } from 'astro:content'
 import MarkdownPostLayout from '../../layouts/MarkdownPostLayout.astro'
 
 export async function getStaticPaths() {
-  const blogEntries = await getCollection('docs')
-  return blogEntries.map(entry => ({
+  const docs = await getCollection('docs')
+  return docs.map((entry: CollectionEntry<'docs'>) => ({
     params: { slug: entry.slug },
     props: { entry },
   }))
+}
+
+export type Props = {
+  entry: CollectionEntry<'docs'>
 }
 
 const { entry } = Astro.props

--- a/src/pages/posts/[...slug].astro
+++ b/src/pages/posts/[...slug].astro
@@ -1,11 +1,11 @@
 ---
-export const prerender = false
+export const prerender = true
 import { getCollection, type CollectionEntry } from 'astro:content'
 import MarkdownPostLayout from '#layouts/MarkdownPostLayout.astro'
 
 export async function getStaticPaths() {
-  const blogEntries = await getCollection('posts')
-  return blogEntries.map(entry => ({
+  const posts = await getCollection('posts')
+  return posts.map((entry: CollectionEntry<'posts'>) => ({
     params: { slug: entry.slug },
     props: { entry },
   }))
@@ -15,7 +15,7 @@ export type Props = {
   entry: CollectionEntry<'posts'>
 }
 
-const { entry } = Astro.props as Props
+const { entry } = Astro.props
 const { Content, headings } = await entry.render()
 ---
 


### PR DESCRIPTION
- Set prerender=true for posts, docs, and content slug pages for better performance
- Add proper TypeScript typing for getStaticPaths entry parameters
- Fix astro-imagetools SSR compatibility with Vite configuration
- Ensure consistent static generation across all content collections

🤖 Generated with [Claude Code](https://claude.ai/code)