### PR TITLE
fix(sanitize): improve domain pattern regex to prevent false matches

### DIFF
--- a/src/utils/sanitize.ts
+++ b/src/utils/sanitize.ts
@@ -195,7 +195,7 @@ function removeUrls(text: string): string {
   const urlPatterns = [
     /https?:\/\/[^\s]+/gi,
     /www\.[^\s]+/gi,
-    /[^\s]+\.[a-z]{2,}[^\s]*/gi // Basic domain pattern
+    /\b(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z]{2,}\b/gi // Improved domain pattern
   ]
 
   let sanitized = text

--- a/src/utils/sanitize.ts
+++ b/src/utils/sanitize.ts
@@ -195,7 +195,7 @@ function removeUrls(text: string): string {
   const urlPatterns = [
     /https?:\/\/[^\s]+/gi,
     /www\.[^\s]+/gi,
-    /\b(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z]{2,}\b/gi // Improved domain pattern
+    /\b(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z]{2,}\b/gi // Improved domain pattern
   ]
 
   let sanitized = text


### PR DESCRIPTION
Replace overly broad domain pattern that incorrectly matched file extensions and version numbers with more specific regex that only matches valid domains.

Fixes #263

Generated with [Claude Code](https://claude.ai/code)