### PR TITLE
security: add environment variable control for dev server host exposure

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,3 +28,8 @@ ENABLE_COMMENTS=true
 ORGANIZATION_ID=your-organization-id
 # Note: Comments require SUPABASE_URL and SUPABASE_ANON_KEY to be configured
 # Run 'npm run db:migrate' to set up the comments table
+
+# Development Server Configuration
+# Set to 'true' to expose dev server to all network interfaces (0.0.0.0)
+# Leave unset or 'false' to restrict to localhost only (more secure)
+# EXPOSE_DEV_SERVER=false

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -53,7 +53,7 @@ export default defineConfig({
   output: 'server',
   vite: {
     server: {
-      host: true,
+      host: process.env.EXPOSE_DEV_SERVER === 'true' ? true : 'localhost',
       allowedHosts: ['476cd5383d8f.ngrok-free.app'],
     },
     ssr: {


### PR DESCRIPTION
Replace hardcoded `host: true` with `EXPOSE_DEV_SERVER` environment variable control.

**Security Improvements**:
- Default behavior restricts dev server to localhost (more secure)
- Explicit opt-in required to expose server to all network interfaces
- Added documentation with security guidance in .env.example

Fixes #249

Generated with [Claude Code](https://claude.ai/code)