### PR TITLE
refactor(toc): improve TOC component with proper types and sidebar la…

### DIFF
--- a/src/components/astro/Toc.astro
+++ b/src/components/astro/Toc.astro
@@ -1,24 +1,20 @@
 ---
-import type { TODO } from '#utils/types.js'
-
 export type Props = {
-  headings?: TODO
+  headings?: { depth: number; slug: string; text: string }[]
   hash?: string
+  title?: string
 }
-const { headings } = Astro.props
+const { headings, title } = Astro.props
 ---
 
 {
-  headings?.length > 1 && (
+  headings && headings.length > 1 && (
     <>
-      {' '}
+      {title ? <h3>{title}</h3> : <h3>On this page</h3>}
       <ul data-list="unstyled">
-        {headings.map((heading: TODO) => (
+        {headings.map(heading => (
           <li>
-            <a href={`#${heading.slug}`}>
-              &#8595;
-              {heading.text}
-            </a>
+            <a href={`#${heading.slug}`}>{heading.text}</a>
           </li>
         ))}
       </ul>
@@ -26,9 +22,3 @@ const { headings } = Astro.props
     </>
   )
 }
-<style>
-  a {
-    font-weight: 600;
-    font-size: var(--fs-5);
-  }
-</style>

--- a/src/components/astro/Toc.astro
+++ b/src/components/astro/Toc.astro
@@ -10,7 +10,7 @@ const { headings, title } = Astro.props
 {
   headings && headings.length > 1 && (
     <>
-      {title ? <h3>{title}</h3> : <h3>On this page</h3>}
+      <h3>{title || 'On this page'}</h3>
       <ul data-list="unstyled">
         {headings.map(heading => (
           <li>

--- a/src/components/astro/Toc.astro
+++ b/src/components/astro/Toc.astro
@@ -1,7 +1,6 @@
 ---
 export type Props = {
   headings?: { depth: number; slug: string; text: string }[]
-  hash?: string
   title?: string
 }
 const { headings, title } = Astro.props

--- a/src/layouts/MarkdownPostLayout.astro
+++ b/src/layouts/MarkdownPostLayout.astro
@@ -64,7 +64,9 @@ const contentRoute: ContentRoute[] = [
     )
   }
   <!-- <h2>{frontmatter.title}</h2> -->
-  <Toc headings={headings} />
+  <div slot="sidebar">
+    <Toc headings={headings} />
+  </div>
 
   <slot />
   {


### PR DESCRIPTION
…yout

- Replace TODO type with proper headings interface { depth, slug, text }[]
- Add configurable title prop with "On this page" default
- Remove inline styles in favor of external styling
- Clean up component logic and remove unnecessary arrow icon
- Integrate TOC into sidebar slot in MarkdownPostLayout
- Improve TypeScript type safety and component reusability

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>