### PR TITLE
fix: add explicit default case handling for database provider switch

### DIFF
--- a/src/libs/database.ts
+++ b/src/libs/database.ts
@@ -302,8 +302,12 @@ export function getDatabase(): Database {
     case 'supabase':
       return new SupabaseDatabase()
 
+    case 'auto':
+      throw new Error('Auto provider should have resolved to a specific provider during detection')
+
     default:
-      throw new Error(`Unsupported database provider: ${detection.recommended}`)
+      // This should never happen with proper TypeScript typing, but provides safety
+      throw new Error(`Unsupported database provider: ${String(detection.recommended)}`)
   }
 }
 


### PR DESCRIPTION
Fixes #286

Adds proper default case handling for the database provider switch statement in `getDatabase()` function.

**Changes:**
- Add explicit 'auto' case with descriptive error message
- Improve default case with String() conversion for safer error handling
- Addresses Copilot suggestion about missing default case handling

Generated with [Claude Code](https://claude.ai/code)