### PR TITLE
chore(dependencies): update @fpkit/acss to version 2.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@astrojs/vercel": "^9.0.0",
         "@axiomhq/js": "^1.3.1",
         "@clerk/astro": "^2.10.8",
-        "@fpkit/acss": "^2.1.0",
+        "@fpkit/acss": "^2.2.0",
         "@fpkit/react": "^0.4.3",
         "@libsql/client": "^0.15.10",
         "@nanostores/react": "^1.0.0",
@@ -3091,9 +3091,9 @@
       "license": "MIT"
     },
     "node_modules/@fpkit/acss": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@fpkit/acss/-/acss-2.1.0.tgz",
-      "integrity": "sha512-UJ50YbDQKknI4HHVpZM7+Sj+lHWXdMnPNDBBVkmpAczXf9liYc3SW4xusjSHpR6JRNuxLgBcMqJZmchxXaqKSg==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@fpkit/acss/-/acss-2.2.0.tgz",
+      "integrity": "sha512-nP9df1FtY6/3BVcL4WQjKlNMp6T9kL8vSkRoTo3MxOlZfOHAOr5FSsfZ+UlpBp7jP2a+M0YStunE2L54ktik8w==",
       "license": "MIT",
       "dependencies": {
         "focus-trap": "^7.5.2",

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "@astrojs/vercel": "^9.0.0",
     "@axiomhq/js": "^1.3.1",
     "@clerk/astro": "^2.10.8",
-    "@fpkit/acss": "^2.1.0",
+    "@fpkit/acss": "^2.2.0",
     "@fpkit/react": "^0.4.3",
     "@libsql/client": "^0.15.10",
     "@nanostores/react": "^1.0.0",


### PR DESCRIPTION
Updated the @fpkit/acss package from version 2.1.0 to 2.2.0 in both package.json and package-lock.json to incorporate the latest features and improvements.

Files changed:
- package.json
- package-lock.json