### PR TITLE
fix(docs): resolve broken gallery nav links with empty-state pages

### DIFF
--- a/docs/artifacts/index.html
+++ b/docs/artifacts/index.html
@@ -1,0 +1,85 @@
+<!doctype html>
+<!-- ponytail: placeholder empty state so the Plans gallery's Artifacts tab resolves.
+     The artifact-tools generator overwrites this file once an artifact exists. -->
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Artifacts Library</title>
+    <style>
+      :root {
+        --paper: #fcfcfa;
+        --panel: #ffffff;
+        --ink: #16151c;
+        --ink-3: #6e6a80;
+        --rule: #e6e3ec;
+        --accent: #4a2fe0;
+        color-scheme: light;
+      }
+      @media (prefers-color-scheme: dark) {
+        :root {
+          --paper: #121118;
+          --panel: #1a1922;
+          --ink: #edebf3;
+          --ink-3: #8b87a0;
+          --rule: #2c2a38;
+          --accent: #a594ff;
+          color-scheme: dark;
+        }
+      }
+      body {
+        margin: 0;
+        min-height: 100vh;
+        display: grid;
+        place-items: center;
+        padding: 2rem;
+        background: var(--paper);
+        color: var(--ink);
+        font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+      }
+      .empty {
+        max-width: 34rem;
+        text-align: center;
+        background: var(--panel);
+        border: 1px solid var(--rule);
+        border-radius: 4px;
+        padding: 2.5rem 2rem;
+      }
+      h1 {
+        margin: 0 0 0.5rem;
+        font-size: 1.5rem;
+        font-family: ui-monospace, "SF Mono", SFMono-Regular, Menlo, monospace;
+      }
+      p {
+        margin: 0 0 1.5rem;
+        color: var(--ink-3);
+        line-height: 1.6;
+      }
+      code {
+        font-family: ui-monospace, "SF Mono", SFMono-Regular, Menlo, monospace;
+        color: var(--ink);
+      }
+      nav a {
+        color: var(--accent);
+        text-decoration: none;
+        margin: 0 0.5rem;
+      }
+      nav a:hover,
+      nav a:focus-visible {
+        text-decoration: underline;
+      }
+    </style>
+  </head>
+  <body>
+    <main class="empty">
+      <h1>Artifacts Library</h1>
+      <p>
+        No artifacts yet. Publish one with the <code>artifact-tools</code> skills to list it here.
+      </p>
+      <nav aria-label="Collections">
+        <a href="../index.html">Home</a>
+        <a href="../plans/index.html">Plans</a>
+      </nav>
+    </main>
+  </body>
+</html>

--- a/docs/media/social/index.html
+++ b/docs/media/social/index.html
@@ -1,0 +1,85 @@
+<!doctype html>
+<!-- ponytail: placeholder empty state so the Plans gallery's Social tab resolves.
+     The media-library generator overwrites this file once a card exists. -->
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Social Library</title>
+    <style>
+      :root {
+        --paper: #fcfcfa;
+        --panel: #ffffff;
+        --ink: #16151c;
+        --ink-3: #6e6a80;
+        --rule: #e6e3ec;
+        --accent: #4a2fe0;
+        color-scheme: light;
+      }
+      @media (prefers-color-scheme: dark) {
+        :root {
+          --paper: #121118;
+          --panel: #1a1922;
+          --ink: #edebf3;
+          --ink-3: #8b87a0;
+          --rule: #2c2a38;
+          --accent: #a594ff;
+          color-scheme: dark;
+        }
+      }
+      body {
+        margin: 0;
+        min-height: 100vh;
+        display: grid;
+        place-items: center;
+        padding: 2rem;
+        background: var(--paper);
+        color: var(--ink);
+        font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+      }
+      .empty {
+        max-width: 34rem;
+        text-align: center;
+        background: var(--panel);
+        border: 1px solid var(--rule);
+        border-radius: 4px;
+        padding: 2.5rem 2rem;
+      }
+      h1 {
+        margin: 0 0 0.5rem;
+        font-size: 1.5rem;
+        font-family: ui-monospace, "SF Mono", SFMono-Regular, Menlo, monospace;
+      }
+      p {
+        margin: 0 0 1.5rem;
+        color: var(--ink-3);
+        line-height: 1.6;
+      }
+      code {
+        font-family: ui-monospace, "SF Mono", SFMono-Regular, Menlo, monospace;
+        color: var(--ink);
+      }
+      nav a {
+        color: var(--accent);
+        text-decoration: none;
+        margin: 0 0.5rem;
+      }
+      nav a:hover,
+      nav a:focus-visible {
+        text-decoration: underline;
+      }
+    </style>
+  </head>
+  <body>
+    <main class="empty">
+      <h1>Social Library</h1>
+      <p>
+        No social cards yet. Run <code>/media-library</code> after creating a card to build this gallery.
+      </p>
+      <nav aria-label="Collections">
+        <a href="../../index.html">Home</a>
+        <a href="../../plans/index.html">Plans</a>
+      </nav>
+    </main>
+  </body>
+</html>

--- a/docs/prototypes/index.html
+++ b/docs/prototypes/index.html
@@ -1,0 +1,86 @@
+<!doctype html>
+<!-- ponytail: placeholder empty state so the Plans gallery's Prototypes tab resolves.
+     The /plan-agent:prototype generator overwrites this file once a prototype exists. -->
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Prototypes Library</title>
+    <style>
+      :root {
+        --paper: #fcfcfa;
+        --panel: #ffffff;
+        --ink: #16151c;
+        --ink-3: #6e6a80;
+        --rule: #e6e3ec;
+        --accent: #4a2fe0;
+        color-scheme: light;
+      }
+      @media (prefers-color-scheme: dark) {
+        :root {
+          --paper: #121118;
+          --panel: #1a1922;
+          --ink: #edebf3;
+          --ink-3: #8b87a0;
+          --rule: #2c2a38;
+          --accent: #a594ff;
+          color-scheme: dark;
+        }
+      }
+      body {
+        margin: 0;
+        min-height: 100vh;
+        display: grid;
+        place-items: center;
+        padding: 2rem;
+        background: var(--paper);
+        color: var(--ink);
+        font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+      }
+      .empty {
+        max-width: 34rem;
+        text-align: center;
+        background: var(--panel);
+        border: 1px solid var(--rule);
+        border-radius: 4px;
+        padding: 2.5rem 2rem;
+      }
+      h1 {
+        margin: 0 0 0.5rem;
+        font-size: 1.5rem;
+        font-family: ui-monospace, "SF Mono", SFMono-Regular, Menlo, monospace;
+      }
+      p {
+        margin: 0 0 1.5rem;
+        color: var(--ink-3);
+        line-height: 1.6;
+      }
+      code {
+        font-family: ui-monospace, "SF Mono", SFMono-Regular, Menlo, monospace;
+        color: var(--ink);
+      }
+      nav a {
+        color: var(--accent);
+        text-decoration: none;
+        margin: 0 0.5rem;
+      }
+      nav a:hover,
+      nav a:focus-visible {
+        text-decoration: underline;
+      }
+    </style>
+  </head>
+  <body>
+    <main class="empty">
+      <h1>Prototypes Library</h1>
+      <p>
+        No prototypes yet. Run <code>/plan-agent:prototype</code> to generate a
+        runnable static-HTML prototype here.
+      </p>
+      <nav aria-label="Collections">
+        <a href="../index.html">Home</a>
+        <a href="../plans/index.html">Plans</a>
+      </nav>
+    </main>
+  </body>
+</html>


### PR DESCRIPTION
## What changed

Adds three placeholder index pages so every tab in the Plans gallery navigation resolves instead of 404ing:

| File | Purpose |
| --- | --- |
| `docs/prototypes/index.html` | Empty state for the Prototypes tab |
| `docs/artifacts/index.html` | Empty state for the Artifacts tab |
| `docs/media/social/index.html` | Empty state for the Social tab |

## Why

`docs/plans/index.html` is generated output from the `plan-agent` `plans-library` skill. Its template renders a fixed five-tab nav (Home, Plans, Prototypes, Artifacts, Social), and the skill spec states that a missing directory simply "counts 0" — it never drops the link. So the generator emitted `../prototypes/index.html`, `../artifacts/index.html`, and `../media/social/index.html` for directories that did not exist, producing three dead links on every published gallery page.

Editing the generated file was rejected as a fix: the next `plans-library` run regenerates it and silently restores the dead links. Creating the missing targets is durable, and each collection's real generator (`/plan-agent:prototype`, `artifact-tools`, `/media-library`) overwrites its own placeholder on first use.

## Reviewer notes

- **Relative links only.** This is a project Pages site served under the `/astro-basics/` path prefix, so an absolute-root `href="/..."` would break. The `docs/media/social/` page sits two levels below `docs/`, so its back-links use `../../`; the other two use `../`. The extra pages were generated by substitution rather than hand-copied, specifically to avoid an off-by-one `../`.
- **Tab counts are unaffected.** They count `*.html` files excluding `index.html`, so the placeholders correctly keep reading 0.
- **Theming.** These use a bare `prefers-color-scheme` block rather than the galleries' `data-theme` toggle machinery — a static empty state has no user choice to persist.
- **No changelog entry**, matching the precedent of #342 and #346, which also touched only the `docs/` publishing site.

## Verification

Previewed locally with `bash scripts/serve-docs.sh 8099` and clicked through every nav tab, including the Social → Plans round trip from the deepest page. Server access log:

```
"GET /prototypes/index.html"   200
"GET /media/social/index.html" 200
"GET /artifacts/index.html"    200
```

Both light and dark rendering verified in-browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added placeholder library pages for Artifacts, Social Media, and Prototypes.
  - Added responsive light and dark theme support.
  - Added empty-state guidance and navigation links to Home and Plans.
  - Included instructions indicating when generated content will replace each placeholder.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->