### PR TITLE
fix(ui): separate hero CTA hierarchy and add missing button states

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Hero call-to-action colour pass** (`src/components/astro/HomeHero.astro`): the two hero CTAs
+  read as a primary and a secondary rather than as two equal buttons
+  - The secondary's border drops from full-chroma `--island` to the neutral `--rule`. Both buttons
+    previously painted the accent at the same strength, so the border measured the same 6.56:1
+    against paper as the primary's fill and the pair carried identical visual weight. The accent
+    stays on the secondary's label, so "colour marks hydration" is unaffected — the rule forbids
+    accenting elements a visitor _cannot_ operate, and the E2E audit only polices that direction
+  - Hover and pressed fills are mixed toward ink in OKLCH at 88% and 78%. `--ink` is near-black in
+    light and near-white in dark, so a single pair of declarations darkens the accent on paper and
+    lightens it on the dark surface with no second theme block. Label contrast rises rather than
+    falls in both: light 6.56 → 7.57 → 8.52, dark
+    6.15 → 6.97 → 7.79. The mix is `oklch` because the same operation in sRGB mutes a saturated
+    violet as it darkens
+  - The primary previously had no colour change on hover at all; `text-decoration: underline` was
+    its only feedback. The underline stays as the non-colour cue, so the state never relies on hue
+  - The secondary promotes its border back to the accent on hover, earning at hover what the
+    resting state trades away for hierarchy
+  - `transition` covers `background-color` and `border-color` only at 150ms. Nothing moves, so
+    there is no motion to gate behind `prefers-reduced-motion`
 - **Typographic hierarchy pass** (`src/styles/_base.scss`, `src/components/astro/Footer.astro`,
   `src/pages/index.astro`): three adjustments so heading, body and supporting text read at
   distinct levels

--- a/src/components/astro/HomeHero.astro
+++ b/src/components/astro/HomeHero.astro
@@ -127,6 +127,17 @@ const specimenCode = [
     --hero-island-bg: var(--island-bg, #f0ebff);
     --hero-rule: var(--rule, #dde1e6);
 
+    /*
+     * Hover and pressed fills, mixed toward ink. `--ink` is near-black in light
+     * and near-white in dark, so one pair of declarations darkens the accent on
+     * paper and lightens it on the dark surface -- no second theme block, and
+     * the label's contrast rises rather than falls in both directions. Mixed in
+     * oklch so the darkened accent keeps its chroma; the same mix in sRGB
+     * muddies a saturated violet.
+     */
+    --hero-island-hover: color-mix(in oklch, var(--hero-island) 88%, var(--hero-ink));
+    --hero-island-active: color-mix(in oklch, var(--hero-island) 78%, var(--hero-ink));
+
     align-items: start;
     box-sizing: border-box;
     color: var(--hero-ink);
@@ -243,20 +254,53 @@ const specimenCode = [
     font-weight: 600;
     padding: 0.6875rem 1.25rem;
     text-decoration: none;
+
+    /* Colour only. Nothing here moves, so there is no motion to suppress
+       under `prefers-reduced-motion`. */
+    transition:
+      background-color var(--transition-duration-150, 150ms) ease-out,
+      border-color var(--transition-duration-150, 150ms) ease-out;
   }
 
+  /*
+   * The secondary carries the accent on its label alone; its border drops to
+   * the neutral rule. Both buttons previously painted the border in full-chroma
+   * `--island`, which measured the same 6.56:1 as the primary's fill and left
+   * the pair reading as two equal calls to action. The accent still marks the
+   * control -- the direction only forbids accenting things a visitor cannot
+   * operate -- so the e2e assertion is unaffected.
+   */
   .home-hero .home-hero__button--ghost {
     background: transparent;
+    border-color: var(--hero-rule);
     color: var(--hero-island);
   }
 
   .home-hero .home-hero__button:hover {
+    background: var(--hero-island-hover);
+    border-color: var(--hero-island-hover);
+
+    /* Non-colour hover cue, so the state does not rely on hue alone. */
     text-decoration: underline;
     text-underline-offset: 3px;
   }
 
+  .home-hero .home-hero__button:active {
+    background: var(--hero-island-active);
+    border-color: var(--hero-island-active);
+  }
+
+  /* Hover is where the secondary earns its border: the tint arrives and the
+     rule gives way to the accent, which is the affordance the resting state
+     trades away for hierarchy. */
   .home-hero .home-hero__button--ghost:hover {
     background: var(--hero-island-bg);
+    border-color: var(--hero-island);
+  }
+
+  .home-hero .home-hero__button--ghost:active {
+    background: color-mix(in oklch, var(--hero-island) 18%, transparent);
+    border-color: var(--hero-island);
   }
 
   .home-hero .home-hero__button:focus-visible {


### PR DESCRIPTION
## What changed

The two homepage hero CTAs now read as a primary and a secondary. Colour only; no markup, layout, or copy changes.

`src/components/astro/HomeHero.astro`

1. **Secondary border drops to the neutral `--rule`.** Both buttons previously painted `--island` at full chroma, so the secondary's border measured the same **6.56:1** against paper as the primary's fill and the pair carried identical visual weight.
2. **Primary gains hover and pressed fills.** It previously had no colour change on hover at all; `text-decoration: underline` was its only feedback.
3. **Secondary promotes its border back to the accent on hover**, earning at hover what the resting state trades away for hierarchy.

## Why this is safe against the direction rule

`--island` still marks the control: the secondary keeps the accent on its label, and gains it on the border at hover. The rule in `_design-tokens.scss` forbids accenting elements a visitor **cannot** operate, and the audit at `e2e/homepage-design-direction.spec.ts:273` only polices that direction. Removing an accent border strictly shrinks the offender surface it inspects.

## The one non-obvious line

```css
--hero-island-hover: color-mix(in oklch, var(--hero-island) 88%, var(--hero-ink));
```

`--ink` is near-black in light and near-white in dark, so **one declaration produces the correct direction in both themes** — it darkens the accent on paper and lightens it on the dark surface. No media block, no second token set, and label contrast rises either way instead of falling.

`oklch` is load-bearing: the same mix in sRGB drags a saturated violet toward mud, because sRGB interpolation sheds chroma as it darkens.

## Measured

Rasterised to canvas for true sRGB — Chrome serialises `color-mix` output as `oklch(...)`, which a naive `getComputedStyle` parse reads as RGB and reports wrong.

| state | light | dark |
|---|---|---|
| primary rest | `#5b2cf5` · 6.56:1 | `#9b7dff` · 6.15:1 |
| primary hover | `#512dd7` · **7.57:1** | `#a38bfe` · **6.97:1** |
| primary active | `#482dbf` · **8.52:1** | `#ab97fd` · **7.79:1** |
| secondary border rest | `#dde1e6` (was accent) | `#262c33` (was accent) |
| secondary border hover | `#5b2cf5` | `#9b7dff` |
| secondary label on hover tint | 5.77:1 | 5.51:1 |

Every state clears WCAG AA in both schemes, and every primary state is now **higher** contrast than before.

Confirmed on real pointer hover, not computed tokens alone: primary `#9b7dff → #a38bfe`, secondary border `#262c33 → #9b7dff`.

## Reviewer notes

- **The branch name is stale.** `claude/clerk-signin-nav-button-22ce0d` is from a separate investigation in the same session: the Clerk auth button missing from the nav. That turned out to be a missing `.env` in the git worktree (worktrees only carry tracked files, and `.env` is gitignored), so it produced **no code change**. The markup at `src/layouts/Base.astro:97` was already correct. Nothing in this PR relates to Clerk.
- **The `transition` is colour-only** (`background-color`, `border-color`, 150ms). Nothing moves, so it is deliberately not gated behind `prefers-reduced-motion`.
- **The underline hover cue stays** on both buttons, so the hover state never depends on hue alone.
- **I did not run the E2E suite.** I read the accent audit and reasoned about it rather than executing it. Worth a CI run before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)