### PR TITLE
chore: ignore .env*.local files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ pnpm-debug.log*
 .env
 .env.production
 .env.backup
+.env*.local
 
 # macOS-specific files
 .DS_Store


### PR DESCRIPTION
## Summary

- Add `.env*.local` to `.gitignore`

## Changes

`.gitignore` covered `.env`, `.env.production`, and `.env.backup`, but not the
`.env.local` family that Astro/Vite loads on top of `.env`. Any locally created
`.env.local` (or `.env.development.local`, etc.) was therefore trackable and
would be picked up by a broad `git add`, putting real credentials — Clerk secret
key, Turso auth token, Supabase service role key — one command away from being
committed.

The `.env*.local` glob covers the whole Vite override family in a single rule.

## Test Plan

- [x] `git check-ignore -v .env.local` — matches `.gitignore:20:.env*.local` (verified in the authoring session)
- [x] `git status --short` with a real `.env.local` present shows no untracked env file (verified)
- [ ] `npm run lint:styles` / `npm test` — not run; this change touches no source files


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project exclusions to prevent local environment-variable files from being included in version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->